### PR TITLE
fix: update input name for suboption quantity in ProductExtraSuboption

### DIFF
--- a/src/components/Stores/ProductExtraSuboption/index.js
+++ b/src/components/Stores/ProductExtraSuboption/index.js
@@ -304,7 +304,7 @@ export const ProductExtraSuboption = (props) => {
         {(typeof settingChangeState?.changes?.allow_suboption_quantity !== 'undefined' ? settingChangeState?.changes?.allow_suboption_quantity : optionState?.option?.allow_suboption_quantity) && (
           <InputWrapper>
             <Controller
-              name='half_price'
+              name='max'
               control={control}
               render={({ onChange, value }) => (
                 <Input


### PR DESCRIPTION
Story: https://app.asana.com/0/1164464536714178/1209291618353593