### PR TITLE
fix: handle empty content in ContentForm note initialization

### DIFF
--- a/src/components/MyProducts/ContentForm/index.js
+++ b/src/components/MyProducts/ContentForm/index.js
@@ -121,6 +121,10 @@ const ContentFormUI = (props) => {
 
   const onInit = (note) => {
     note.reset()
+    if (!content) {
+      note.insertText('')
+      return
+    }
     const regex = /(\<\w*)((\s\/\>)|(.*\<\/\w*\>))/i
     if (content?.match(regex) !== null) {
       note.replace(content)


### PR DESCRIPTION
Story: https://github.com/Ordering-Inc/ordering-components-admin/pull/727