### PR TITLE
feat: add new webhook option for driver waiting for customer in WebhookListSelector

### DIFF
--- a/src/components/Settings/WebhookListSelector/index.js
+++ b/src/components/Settings/WebhookListSelector/index.js
@@ -28,6 +28,7 @@ export const WebhookListSelector = (props) => {
     { value: 'orders_delivery_completed_driver', content: <Option>{t('ORDERS_DELIVERY_COMPLETED_DRIVER', 'Order delivery completed by driver')}</Option> },
     { value: 'orders_delivery_failed_driver', content: <Option>{t('ORDERS_DELIVERY_FAILED_DRIVER', 'Order delivery failed by driver')}</Option> },
     { value: 'orders_unassigned_driver', content: <Option>{t('ORDERS_UNASSIGNED_DRIVER', 'Order unassigned driver')}</Option> },
+    { value: 'orders_driver_waiting_for_customer', content: <Option>{t('ORDERS_DRIVER_WAITING_FOR_CUSTOMER', 'Order driver waiting for customer')}</Option> },
     { value: 'preorder_updated', content: <Option>{t('PREORDER_UPDATED', 'Preorder updated')}</Option> },
     { value: 'drivers_changes', content: <Option>{t('DRIVERS_CHANGES', 'Driver changes')}</Option> }
   ]


### PR DESCRIPTION
- Introduced a new webhook option for 'orders_driver_waiting_for_customer' to enhance the webhook functionality.
- Updated the component to include the new option, improving the flexibility of webhook configurations.

Story: https://app.asana.com/1/306583973076188/project/1164464536714178/task/1213822714237398?focus=true